### PR TITLE
[DOI-616] Test plugin with Wordpress v6.0

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,9 +3,9 @@ Contributors: fromdoppler
 Donate link: www.fromdoppler.com
 Tags: email marketing
 Requires at least: 4.9
-Tested up to: 5.9.2
+Tested up to: 6.0.0
 Requires PHP: 5.6.4
-Stable tag: 1.0.7
+Stable tag: 1.0.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
The plugin works fine with wordpress v6.0, I'm updating the readme file to remove version warnings in the wordpress platform.
This is already pushed into the svn.